### PR TITLE
Add block listener to fabricstore

### DIFF
--- a/fabricstore/fabricstore.go
+++ b/fabricstore/fabricstore.go
@@ -120,7 +120,7 @@ func New(config *Config) (*FabricStore, error) {
 		return nil, err
 	}
 
-	eventHub, err := getEventHub(client)
+	eventHub, err := getEventHub(client, clientConfig.Organization)
 	if err != nil {
 		return nil, err
 	}

--- a/fabricstore/util_test.go
+++ b/fabricstore/util_test.go
@@ -46,8 +46,8 @@ func NewTestClient() *FabricStore {
 		Commit:      "00000000000000000000000000000000",
 	}
 	s := FabricStore{
-		fabricClient: &MockClient{},
-		config:       &config,
+		channelClient: &MockClient{},
+		config:        &config,
 	}
 	return &s
 }

--- a/fabricstore/utils.go
+++ b/fabricstore/utils.go
@@ -1,0 +1,202 @@
+package fabricstore
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+	fab "github.com/hyperledger/fabric-sdk-go/api/apifabclient"
+	deffab "github.com/hyperledger/fabric-sdk-go/def/fabapi"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fabric-client/events"
+	"github.com/hyperledger/fabric-sdk-go/pkg/fabric-client/orderer"
+	"github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/hyperledger/fabric/protos/utils"
+
+	common "github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric/protos/common"
+	com "github.com/hyperledger/fabric/protos/common"
+
+	log "github.com/sirupsen/logrus"
+
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+func getChannel(client fab.FabricClient, channelID string, orgName string) (fab.Channel, error) {
+	channel, err := client.NewChannel(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	orderers, _ := getOrderers(client)
+	for _, o := range orderers {
+		if err := channel.AddOrderer(o); err != nil {
+			return nil, err
+		}
+	}
+
+	peers, _ := getPeers(client, orgName)
+	for _, p := range peers {
+		if err := channel.AddPeer(p); err != nil {
+			return nil, err
+		}
+	}
+
+	return channel, nil
+}
+
+func getPeers(client fab.FabricClient, org string) ([]fab.Peer, error) {
+	peerConfig, err := client.Config().PeersConfig(org)
+	if err != nil {
+		return nil, err
+	}
+
+	peers := []fab.Peer{}
+	for _, p := range peerConfig {
+		serverHostOverride := ""
+		if str, ok := p.GRPCOptions["ssl-target-name-override"].(string); ok {
+			serverHostOverride = str
+		}
+		peer, err := deffab.NewPeer(p.URL, p.TLSCACerts.Path, serverHostOverride, client.Config())
+		if err != nil {
+			return nil, err
+		}
+		peers = append(peers, peer)
+	}
+
+	return peers, nil
+}
+
+func getOrderers(client fab.FabricClient) ([]*orderer.Orderer, error) {
+	ordererConfigs, err := client.Config().OrderersConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	orderers := []*orderer.Orderer{}
+	for _, o := range ordererConfigs {
+		serverHostOverride := ""
+		if str, ok := o.GRPCOptions["ssl-target-name-override"].(string); ok {
+			serverHostOverride = str
+		}
+		orderer, err := orderer.NewOrderer(o.URL, o.TLSCACerts.Path, serverHostOverride, client.Config())
+		if err != nil {
+			return nil, err
+		}
+		orderers = append(orderers, orderer)
+	}
+
+	return orderers, nil
+}
+
+func getEventHub(client fab.FabricClient) (fab.EventHub, error) {
+	eventHub, err := events.NewEventHub(client)
+	if err != nil {
+		return nil, err
+	}
+	foundEventHub := false
+	peerConfig, err := client.Config().PeersConfig("Org1")
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range peerConfig {
+		if p.URL != "" {
+			log.Infof("EventHub connect to peer (%s)", p.URL)
+			serverHostOverride := ""
+			if str, ok := p.GRPCOptions["ssl-target-name-override"].(string); ok {
+				serverHostOverride = str
+			}
+			eventHub.SetPeerAddr(p.EventURL, p.TLSCACerts.Path, serverHostOverride)
+			foundEventHub = true
+			break
+		}
+	}
+
+	if !foundEventHub {
+		return nil, err
+	}
+
+	return eventHub, nil
+}
+
+func readBlock(block *common.Block) error {
+	txFilter := util.TxValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])
+	for i, txBytes := range block.Data.Data {
+		if txFilter.Flag(i) == pb.TxValidationCode_VALID {
+			cc, err := getChaincodeEvent(txBytes)
+			if err != nil {
+				return err
+			}
+			if cc != nil {
+				fmt.Println(cc.ChaincodeId)
+				fmt.Println(cc.EventName)
+				fmt.Println(cc.TxId)
+				fmt.Println(string(cc.Payload))
+			}
+		}
+	}
+
+	return nil
+}
+
+func getTxPayload(txData []byte) (*com.Payload, error) {
+	if txData == nil {
+		return nil, errors.New("Cannot extract payload from nil transaction")
+	}
+
+	if env, err := utils.GetEnvelopeFromBlock(txData); err != nil {
+		return nil, errors.New("Error getting tx from block")
+	} else if env != nil {
+		payload, err := utils.GetPayload(env)
+		if err != nil {
+			return nil, errors.New("Could not extract payload from envelope")
+		}
+		return payload, nil
+	}
+
+	return nil, nil
+}
+
+func getChaincodeEvent(txData []byte) (*pb.ChaincodeEvent, error) {
+	payload, err := getTxPayload(txData)
+	if err != nil {
+		return nil, err
+	}
+
+	chHeader, err := utils.UnmarshalChannelHeader(payload.Header.ChannelHeader)
+	if err != nil {
+		return nil, errors.New("Could not extract channel header")
+	}
+
+	fmt.Println("ChannelID:", chHeader.ChannelId)
+	fmt.Println("TransactionID:", chHeader.TxId)
+
+	if com.HeaderType(chHeader.Type) == com.HeaderType_ENDORSER_TRANSACTION {
+
+		tx, err := utils.GetTransaction(payload.Data)
+		if err != nil {
+			return nil, errors.New("Error unmarshalling transaction payload")
+		}
+
+		chaincodeActionPayload, err := utils.GetChaincodeActionPayload(tx.Actions[0].Payload)
+		if err != nil {
+			return nil, err
+		}
+
+		chaincodeProposalSpec := &pb.ChaincodeProposalPayload{}
+		if err := proto.Unmarshal(chaincodeActionPayload.ChaincodeProposalPayload, chaincodeProposalSpec); err != nil {
+			return nil, err
+		}
+
+		chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{}
+		if err := proto.Unmarshal(chaincodeProposalSpec.Input, chaincodeInvocationSpec); err != nil {
+			return nil, err
+		}
+
+		fmt.Println("chaincode id : ", chaincodeInvocationSpec.ChaincodeSpec.ChaincodeId.Name)
+
+		for i, a := range chaincodeInvocationSpec.ChaincodeSpec.Input.Args {
+			log.Infof("arg %v is %v", i, string(a))
+		}
+	}
+
+	return nil, nil
+}

--- a/fabricstore/utils.go
+++ b/fabricstore/utils.go
@@ -95,13 +95,13 @@ func getOrderers(client fab.FabricClient) ([]*orderer.Orderer, error) {
 	return orderers, nil
 }
 
-func getEventHub(client fab.FabricClient) (fab.EventHub, error) {
+func getEventHub(client fab.FabricClient, orgName string) (fab.EventHub, error) {
 	eventHub, err := events.NewEventHub(client)
 	if err != nil {
 		return nil, err
 	}
 	foundEventHub := false
-	peerConfig, err := client.Config().PeersConfig("Org1")
+	peerConfig, err := client.Config().PeersConfig(orgName)
 	if err != nil {
 		return nil, err
 	}

--- a/fabricstore/utils.go
+++ b/fabricstore/utils.go
@@ -176,6 +176,10 @@ func getChaincodeEvent(txData []byte) (*Transaction, error) {
 			return nil, err
 		}
 
+		if len(tx.Actions) != 1 {
+			return nil, errors.New("Expected exactly one item in transaction actions payload")
+		}
+
 		chaincodeActionPayload, err := utils.GetChaincodeActionPayload(tx.Actions[0].Payload)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- added channel (will be used to query blocks) and eventHub (used to listen to block events) attributes to fabricstore
- added util functions to construct channel and read blocks (extract transactions)
- didSave event is now generated by the onBlock callback

Block listener is a requirement to generate evidences containing the transaction id and the block height. Next step is to implement the new interface and then properly generate evidences.

Resolves #10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/fabricstore/11)
<!-- Reviewable:end -->
