### PR TITLE
cmd: retry connecting to fabric network

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Stratumn SAS. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "errors"
+
+var errMaxRetriesReached = errors.New("exceeded retry limit")
+
+// Func represents functions that can be retried.
+type Func func(attempt int) (retry bool, err error)
+
+// Retry keeps trying the function until the second argument
+// returns false, or no error is returned.
+func Retry(fn Func, maxRetries int) error {
+	var err error
+	var cont bool
+	attempt := 1
+	for {
+		cont, err = fn(attempt)
+		if !cont || err == nil {
+			break
+		}
+		attempt++
+		if maxRetries > 0 && attempt > maxRetries {
+			return errMaxRetriesReached
+		}
+	}
+	return err
+}
+
+// IsMaxRetries checks whether the error is due to hitting the
+// maximum number of retries or not.
+func IsMaxRetries(err error) bool {
+	return err == errMaxRetriesReached
+}


### PR DESCRIPTION
Retry function is necessary when launching fabricstore via a docker-compose file along with fabric network as network might not be ready when fabricstore container launches.

Resolves #18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/fabricstore/19)
<!-- Reviewable:end -->
