### PR TITLE
fabricstore: fix block parser

### DIFF
--- a/fabricstore/utils.go
+++ b/fabricstore/utils.go
@@ -206,5 +206,5 @@ func getChaincodeEvent(txData []byte) (*Transaction, error) {
 		return transaction, nil
 	}
 
-	return nil, nil
+	return nil, errors.New("Not an endorser transaction")
 }


### PR DESCRIPTION
Previous parser would add nil transactions to transaction slice if the block had only non endorser transactions.

Resolves #21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/fabricstore/22)
<!-- Reviewable:end -->
